### PR TITLE
Use paleorun instead of run for output container in scripts

### DIFF
--- a/examples/CONPSFeMn/PALEO_examples_sediment_NNFeMn.jl
+++ b/examples/CONPSFeMn/PALEO_examples_sediment_NNFeMn.jl
@@ -70,14 +70,14 @@ tspan=(0.0, 100000.0)
 
 initial_state, modeldata = PALEOmodel.initialize!(model)
 
-run = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())
+paleorun = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())
 
 # PTC, Newton, no line search
 # Bounds and max step size for Newton solve. NB requires min/max ratio for robustness so check all tracers initial_value is not zero
 # newton_min, newton_max, newton_min_ratio, newton_max_ratio = 1e-80, 1e6, 0.1, 10.0
 newton_min, newton_max, newton_min_ratio, newton_max_ratio = 1e-30, 1e6, 1e-2, 1e2
 PALEOmodel.SteadyState.steadystate_ptcForwardDiff(
-    run, initial_state, modeldata, tspan, 1e-6,
+    paleorun, initial_state, modeldata, tspan, 1e-6,
     deltat_fac=2.0,
     solvekwargs=(
         ftol=1e-7,
@@ -111,32 +111,32 @@ pager = PALEOmodel.PlotPager((1, 4), (legend_background_color=nothing, margin=(5
 
 solute_burial_flux=true
 
-plot_phi(run.output; colrange, pager)
-plot_w(run.output; colrange, pager)
-plot_biorates(run.output; colrange, pager)
-plot_Corg_O2(run.output; Corgs=["Corg",], colT=[first(tspan), last(tspan)], colrange, pager)
-plot_Corg_RCmultiG(run.output; colrange, pager)
-plot_solutes(run.output; colT=[first(tspan), last(tspan)], solutes=["TP", "DIC", "NO3", "NO2", "TNH3", "SO4", "TH2S", "CH4", "H2", "MnII", "FeII"], colrange, pager)
-plot_solids(run.output; colT=[first(tspan), last(tspan)], solids=["MnHR", "MnMR", "FeHR", "FeMR", "FePR", "S0", "FeSm", "FeS2pyr",], colrange, pager)
-plot_budget(run.output; name="P", solids=["Corg"], stoich_factors=Dict("Corg"=>1/106), solutes=["TP"], solute_burial_flux,
+plot_phi(paleorun.output; colrange, pager)
+plot_w(paleorun.output; colrange, pager)
+plot_biorates(paleorun.output; colrange, pager)
+plot_Corg_O2(paleorun.output; Corgs=["Corg",], colT=[first(tspan), last(tspan)], colrange, pager)
+plot_Corg_RCmultiG(paleorun.output; colrange, pager)
+plot_solutes(paleorun.output; colT=[first(tspan), last(tspan)], solutes=["TP", "DIC", "NO3", "NO2", "TNH3", "SO4", "TH2S", "CH4", "H2", "MnII", "FeII"], colrange, pager)
+plot_solids(paleorun.output; colT=[first(tspan), last(tspan)], solids=["MnHR", "MnMR", "FeHR", "FeMR", "FePR", "S0", "FeSm", "FeS2pyr",], colrange, pager)
+plot_budget(paleorun.output; name="P", solids=["Corg"], stoich_factors=Dict("Corg"=>1/106), solutes=["TP"], solute_burial_flux,
     pager, colrange, concxscale=:log10, concxlims=(1e-3, 1e3))
-plot_budget(run.output; name="Mn", solids=["MnHR", "MnMR"], solutes=["MnII"], solute_burial_flux,
+plot_budget(paleorun.output; name="Mn", solids=["MnHR", "MnMR"], solutes=["MnII"], solute_burial_flux,
     pager, colrange, concxscale=:log10, concxlims=(1e-3, 1e3))
-plot_budget(run.output; name="Fe", solids=["FeHR", "FeMR", "FePR", "FeSm", "FeS2pyr"], solutes=["FeII"], solute_burial_flux,
+plot_budget(paleorun.output; name="Fe", solids=["FeHR", "FeMR", "FePR", "FeSm", "FeS2pyr"], solutes=["FeII"], solute_burial_flux,
     pager, colrange, concxscale=:log10, concxlims=(1e-3, 1e4))
-plot_budget(run.output; name="S", solids=["S0", "FeSm", "FeS2pyr"], solutes=["TH2S", "SO4"], stoich_factors=Dict("FeS2pyr"=>2), solute_burial_flux,
+plot_budget(paleorun.output; name="S", solids=["S0", "FeSm", "FeS2pyr"], solutes=["TH2S", "SO4"], stoich_factors=Dict("FeS2pyr"=>2), solute_burial_flux,
     pager, colrange, concxscale=:log10, concxlims=(1e-3, 1e4), fluxylims=(-1, 1) )
-plot_rates(run.output; colT=[first(tspan), last(tspan)], remin_rates=["reminOrgOxO2", "reminOrgOxNO2", "reminOrgOxNO3NO2", "reminOrgOxMnIVOx", "reminOrgOxFeIIIOx", "reminOrgOxSO4", "reminOrgOxCH4"], colrange, pager)
+plot_rates(paleorun.output; colT=[first(tspan), last(tspan)], remin_rates=["reminOrgOxO2", "reminOrgOxNO2", "reminOrgOxNO3NO2", "reminOrgOxMnIVOx", "reminOrgOxFeIIIOx", "reminOrgOxSO4", "reminOrgOxCH4"], colrange, pager)
 
 plot_budgets(
-    run.output;
+    paleorun.output;
     budgets="budgets.net_input_".*["C", "N", "P", "S", "Mn", "Fe", "TAlk"],
     ylims=(-1e-6, 1e-6),
     pager, colrange,
 )
 pager(:newpage)
 
-plot_conc_summary(run.output; species=["O2", "NO3", "NO2", "TNH3", "TP", "TH2S", "FeII", "MnII", "CH4"], pager, colrange, xscale=:log10, xlims=(1e-3, 1e0))
+plot_conc_summary(paleorun.output; species=["O2", "NO3", "NO2", "TNH3", "TP", "TH2S", "FeII", "MnII", "CH4"], pager, colrange, xscale=:log10, xlims=(1e-3, 1e0))
 
 pager(:newpage)
 

--- a/examples/CONPSFeMn/PALEO_examples_sediment_NNFeMnP.jl
+++ b/examples/CONPSFeMn/PALEO_examples_sediment_NNFeMnP.jl
@@ -71,14 +71,14 @@ tspan=(0.0, 100000.0)
 
 initial_state, modeldata = PALEOmodel.initialize!(model)
 
-run = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())
+paleorun = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())
 
 # PTC, Newton, no line search
 # Bounds and max step size for Newton solve. NB requires min/max ratio for robustness so check all tracers initial_value is not zero
 # newton_min, newton_max, newton_min_ratio, newton_max_ratio = 1e-80, 1e6, 0.1, 10.0
 newton_min, newton_max, newton_min_ratio, newton_max_ratio = 1e-30, 1e6, 1e-2, 1e2
 PALEOmodel.SteadyState.steadystate_ptcForwardDiff(
-    run, initial_state, modeldata, tspan, 1e-6,
+    paleorun, initial_state, modeldata, tspan, 1e-6,
     deltat_fac=2.0,
     solvekwargs=(
         ftol=1e-7,
@@ -112,33 +112,33 @@ pager = PALEOmodel.PlotPager((1, 4), (legend_background_color=nothing, margin=(5
 
 solute_burial_flux=true
 
-plot_phi(run.output; colrange, pager)
-plot_w(run.output; colrange, pager)
-plot_biorates(run.output; colrange, pager)
-plot_Corg_O2(run.output; Corgs=["Corg",], colT=[first(tspan), last(tspan)], colrange, pager)
-plot_Corg_RCmultiG(run.output; colrange, pager)
-plot_solutes(run.output; colT=[first(tspan), last(tspan)], solutes=["TP", "DIC", "NO3", "NO2", "TNH3", "SO4", "TH2S", "CH4", "H2", "MnII", "FeII"], colrange, pager)
-plot_solids(run.output; colT=[first(tspan), last(tspan)], solids=["MnHR", "MnMR", "FeHR", "FeMR", "FePR", "S0", "FeSm", "FeS2pyr",], colrange, pager)
-plot_budget(run.output; name="P", solids=["Corg", "PFeHR", "PFeMR", "CFA"], stoich_factors=Dict("Corg"=>1/106), solutes=["TP"], solute_burial_flux,
+plot_phi(paleorun.output; colrange, pager)
+plot_w(paleorun.output; colrange, pager)
+plot_biorates(paleorun.output; colrange, pager)
+plot_Corg_O2(paleorun.output; Corgs=["Corg",], colT=[first(tspan), last(tspan)], colrange, pager)
+plot_Corg_RCmultiG(paleorun.output; colrange, pager)
+plot_solutes(paleorun.output; colT=[first(tspan), last(tspan)], solutes=["TP", "DIC", "NO3", "NO2", "TNH3", "SO4", "TH2S", "CH4", "H2", "MnII", "FeII"], colrange, pager)
+plot_solids(paleorun.output; colT=[first(tspan), last(tspan)], solids=["MnHR", "MnMR", "FeHR", "FeMR", "FePR", "S0", "FeSm", "FeS2pyr",], colrange, pager)
+plot_budget(paleorun.output; name="P", solids=["Corg", "PFeHR", "PFeMR", "CFA"], stoich_factors=Dict("Corg"=>1/106), solutes=["TP"], solute_burial_flux,
     pager, colrange, concxscale=:log10, concxlims=(1e-3, 1e3))
-plot_budget(run.output; name="Mn", solids=["MnHR", "MnMR"], solutes=["MnII"], solute_burial_flux,
+plot_budget(paleorun.output; name="Mn", solids=["MnHR", "MnMR"], solutes=["MnII"], solute_burial_flux,
     pager, colrange, concxscale=:log10, concxlims=(1e-3, 1e3))
-plot_budget(run.output; name="Fe", solids=["FeHR", "FeMR", "FePR", "FeSm", "FeS2pyr"], solutes=["FeII"], solute_burial_flux,
+plot_budget(paleorun.output; name="Fe", solids=["FeHR", "FeMR", "FePR", "FeSm", "FeS2pyr"], solutes=["FeII"], solute_burial_flux,
     pager, colrange, concxscale=:log10, concxlims=(1e-3, 1e4))
-plot_budget(run.output; name="S", solids=["S0", "FeSm", "FeS2pyr"], solutes=["TH2S", "SO4"], stoich_factors=Dict("FeS2pyr"=>2), solute_burial_flux,
+plot_budget(paleorun.output; name="S", solids=["S0", "FeSm", "FeS2pyr"], solutes=["TH2S", "SO4"], stoich_factors=Dict("FeS2pyr"=>2), solute_burial_flux,
     pager, colrange, concxscale=:log10, concxlims=(1e-3, 1e4), fluxylims=(-1, 1) )
-plot_rates(run.output; colT=[first(tspan), last(tspan)], remin_rates=["reminOrgOxO2", "reminOrgOxNO2", "reminOrgOxNO3NO2", "reminOrgOxMnIVOx", "reminOrgOxFeIIIOx", "reminOrgOxSO4", "reminOrgOxCH4"], colrange, pager)
+plot_rates(paleorun.output; colT=[first(tspan), last(tspan)], remin_rates=["reminOrgOxO2", "reminOrgOxNO2", "reminOrgOxNO3NO2", "reminOrgOxMnIVOx", "reminOrgOxFeIIIOx", "reminOrgOxSO4", "reminOrgOxCH4"], colrange, pager)
 
 plot_budgets(
-    run.output;
+    paleorun.output;
     budgets="budgets.net_input_".*["C", "N", "P", "S", "Mn", "Fe", "TAlk"],
     ylims=(-1e-6, 1e-6),
     pager, colrange,
 )
 pager(:newpage)
 
-plot_conc_summary(run.output; species=["O2", "NO3", "NO2", "TNH3", "TP", "TH2S", "FeII", "MnII", "CH4", "F"], pager, colrange, xscale=:log10, xlims=(1e-3, 1e0))
-plot_conc_summary(run.output; species=["Corg", "FeHR", "FeMR", "FePR", "FeSm", "FeS2pyr", "PFeHR", "PFeMR", "CFA"], pager, colrange, xscale=:log10, xlims=(1e-3, 1e4))
+plot_conc_summary(paleorun.output; species=["O2", "NO3", "NO2", "TNH3", "TP", "TH2S", "FeII", "MnII", "CH4", "F"], pager, colrange, xscale=:log10, xlims=(1e-3, 1e0))
+plot_conc_summary(paleorun.output; species=["Corg", "FeHR", "FeMR", "FePR", "FeSm", "FeS2pyr", "PFeHR", "PFeMR", "CFA"], pager, colrange, xscale=:log10, xlims=(1e-3, 1e4))
 
 pager(:newpage)
 

--- a/examples/FOAM/PALEO_examples_sediment_FOAM.jl
+++ b/examples/FOAM/PALEO_examples_sediment_FOAM.jl
@@ -69,14 +69,14 @@ tspan=(0.0, 1e5)
 
 initial_state, modeldata = PALEOmodel.initialize!(model)
 
-run = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())
+paleorun = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())
 
 # PTC, Newton, no line search
 # Bounds and max step size for Newton solve. NB requires min/max ratio for robustness so check all tracers initial_value is not zero
 # newton_min, newton_max, newton_min_ratio, newton_max_ratio = 1e-80, 1e6, 0.1, 10.0
 newton_min, newton_max, newton_min_ratio, newton_max_ratio = 1e-30, 1e6, 1e-2, 1e2
 PALEOmodel.SteadyState.steadystate_ptcForwardDiff(
-    run, initial_state, modeldata, tspan, 1e-6,
+    paleorun, initial_state, modeldata, tspan, 1e-6,
     deltat_fac=2.0,
     solvekwargs=(
         # ftol=1e-7,
@@ -106,40 +106,40 @@ solute_burial_flux=true
 if verbose_plots    
     pager = PALEOmodel.PlotPager((1, 4), (legend_background_color=nothing, margin=(5, :mm)))
 
-    plot_phi(run.output; colrange, pager)
-    plot_w(run.output; colrange, pager)
-    plot_biorates(run.output; colrange, pager)
-    plot_Corg_O2(run.output; Corgs=["Corg",], colT=[first(tspan), last(tspan)], colrange, pager)
-    plot_Corg_RCmultiG(run.output; Corg_indices=1:12, colrange, pager)
-    plot_solutes(run.output; colT=[first(tspan), last(tspan)], solutes=["TP", "DIC", "TAlk",  "NO3", "TNH3", "SO4", "TH2S", "CH4",  "H2", "MnII",], colrange, pager)
-    # plot_sediment_FeS_summary(run.output; colrange, pager)
-    plot_solids(run.output; colT=[first(tspan), last(tspan)], solids=["MnHR", "MnMR", "FeHR", "FeMR", "FePR", "FeSm", "FeS2pyr",], colrange, pager)
-    plot_carbchem(run.output; include_constraint_error=true, colT=last(tspan), colrange, pager)
-    plot_budget(run.output; name="C", solids=["Corg", "CaCO3calc", "CaCO3arag", "MnCO3rhod"], solutes=["DIC", "CH4"], solute_burial_flux,
+    plot_phi(paleorun.output; colrange, pager)
+    plot_w(paleorun.output; colrange, pager)
+    plot_biorates(paleorun.output; colrange, pager)
+    plot_Corg_O2(paleorun.output; Corgs=["Corg",], colT=[first(tspan), last(tspan)], colrange, pager)
+    plot_Corg_RCmultiG(paleorun.output; Corg_indices=1:12, colrange, pager)
+    plot_solutes(paleorun.output; colT=[first(tspan), last(tspan)], solutes=["TP", "DIC", "TAlk",  "NO3", "TNH3", "SO4", "TH2S", "CH4",  "H2", "MnII",], colrange, pager)
+    # plot_sediment_FeS_summary(paleorun.output; colrange, pager)
+    plot_solids(paleorun.output; colT=[first(tspan), last(tspan)], solids=["MnHR", "MnMR", "FeHR", "FeMR", "FePR", "FeSm", "FeS2pyr",], colrange, pager)
+    plot_carbchem(paleorun.output; include_constraint_error=true, colT=last(tspan), colrange, pager)
+    plot_budget(paleorun.output; name="C", solids=["Corg", "CaCO3calc", "CaCO3arag", "MnCO3rhod"], solutes=["DIC", "CH4"], solute_burial_flux,
         pager, colrange, fluxylims=(-4, 4), concxscale=:log10, concxlims=(1e-3, 1e4))
-    plot_budget(run.output; name="TP", solids=["Corg", "PFeHR", "PFeMR", "CFA"], stoich_factors=Dict("Corg"=>1/106), solutes=["TP"], solute_burial_flux,
+    plot_budget(paleorun.output; name="TP", solids=["Corg", "PFeHR", "PFeMR", "CFA"], stoich_factors=Dict("Corg"=>1/106), solutes=["TP"], solute_burial_flux,
         pager, colrange, concxscale=:log10, concxlims=(1e-3, 1e3))
-    plot_budget(run.output; name="Mn", solids=["MnHR", "MnMR", "MnCO3rhod"], solutes=["MnII"], solute_burial_flux,
+    plot_budget(paleorun.output; name="Mn", solids=["MnHR", "MnMR", "MnCO3rhod"], solutes=["MnII"], solute_burial_flux,
         pager, colrange, concxscale=:log10, concxlims=(1e-3, 1e4))
     # don't include solute_burial_flux as FeIItot is already counted once as a solid
-    plot_budget(run.output; name="Fe", solids=["FeHR", "FeMR", "FePR", "FeMag", "FeSm", "FeS2pyr", "FeIItot"], solutes=["FeIItot"], extras=["budgets.Biotite_dissolflux"], solute_burial_flux=false,
+    plot_budget(paleorun.output; name="Fe", solids=["FeHR", "FeMR", "FePR", "FeMag", "FeSm", "FeS2pyr", "FeIItot"], solutes=["FeIItot"], extras=["budgets.Biotite_dissolflux"], solute_burial_flux=false,
         stoich_factors=Dict("FeMag"=>3, "budgets.Biotite_dissolflux"=>2),
         pager, colrange, concxscale=:log10, concxlims=(1e-3, 1e4))
-    plot_budget(run.output; name="S", solids=["FeSm", "FeS2pyr", "S0"], solutes=["TH2S", "SO4"], solute_burial_flux,
+    plot_budget(paleorun.output; name="S", solids=["FeSm", "FeS2pyr", "S0"], solutes=["TH2S", "SO4"], solute_burial_flux,
         stoich_factors=Dict("FeS2pyr"=>2,),
         pager, colrange, concxscale=:log10, concxlims=(1e-3, 1e4), fluxylims=(-1, 1) )
     # TODO TAlk conservation requires counting adsorbed FeII that is buried ?!
-    plot_budget(run.output; name="TAlk", solids=["FeIItot"], solutes=["TAlk", "SO4", "NO3", "TNH3", "TP", "MnII", "FeIItot", "Ca", "Mg", "K", "Na", "F"], solute_burial_flux,
+    plot_budget(paleorun.output; name="TAlk", solids=["FeIItot"], solutes=["TAlk", "SO4", "NO3", "TNH3", "TP", "MnII", "FeIItot", "Ca", "Mg", "K", "Na", "F"], solute_burial_flux,
         stoich_factors=Dict("SO4"=>2, "NO3"=>1, "TNH3"=>-1, "TP"=>1, "MnII"=>-2, "FeIItot"=>-2, "Ca"=>-2, "Mg"=>-2, "K"=>-1), 
         pager, colrange, concxscale=:identity, concxlims=(-Inf, Inf), fluxylims=(-10, 10) )
-    plot_rates(run.output; colT=[first(tspan), last(tspan)], plot_freminOrgTot=false, remin_rates=["reminOrgOxO2", "reminOrgOxNO3", "reminOrgOxSO4", "reminOrgOxCH4"], colrange, pager)
-    plot_conc_summary(run.output; species=["DIC", "O2", "TP", "SO4", "TH2S", "CH4"], pager, colrange, xscale=:log10, xlims=(1e-3, 1e2))
+    plot_rates(paleorun.output; colT=[first(tspan), last(tspan)], plot_freminOrgTot=false, remin_rates=["reminOrgOxO2", "reminOrgOxNO3", "reminOrgOxSO4", "reminOrgOxCH4"], colrange, pager)
+    plot_conc_summary(paleorun.output; species=["DIC", "O2", "TP", "SO4", "TH2S", "CH4"], pager, colrange, xscale=:log10, xlims=(1e-3, 1e2))
 end
 
 # summary plots
 pager = PALEOmodel.PlotPager((2, 4), (legend_background_color=nothing, margin=(5, :mm)))
 plot_budgets(
-    run.output;
+    paleorun.output;
     budgets="budgets.net_input_".*["C", "N", "P", "S", "Mn", "Fe", "TAlk"],
     ylims=(-1e-6, 1e-6),
     pager, colrange,
@@ -147,7 +147,7 @@ plot_budgets(
 pager(:newpage)
 
 plot_summary_stacked(
-    run.output; 
+    paleorun.output; 
     species=["MnII", "FeII", "SO4", "CH4", "FeMag", "TNH3", "Ca", "DIC", "TP", "F", "CFA", "O2", "NO3", "TH2S", "TAlk",],
     others=["NotOmega_CFA",],
     pager, colrange

--- a/examples/FOAM/PALEO_examples_sediment_FOAM_minimal.jl
+++ b/examples/FOAM/PALEO_examples_sediment_FOAM_minimal.jl
@@ -44,14 +44,14 @@ tspan=(0.0, 1e6)
 
 initial_state, modeldata = PALEOmodel.initialize!(model)
 
-run = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())
+paleorun = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())
 
 # PTC, Newton, no line search
 # Bounds and max step size for Newton solve. NB requires min/max ratio for robustness so check all tracers initial_value is not zero
 # newton_min, newton_max, newton_min_ratio, newton_max_ratio = 1e-80, 1e6, 0.1, 10.0
 newton_min, newton_max, newton_min_ratio, newton_max_ratio = 1e-30, 1e6, 1e-2, 1e2
 PALEOmodel.SteadyState.steadystate_ptcForwardDiff(
-    run, initial_state, modeldata, tspan, 1e-6,
+    paleorun, initial_state, modeldata, tspan, 1e-6,
     deltat_fac=2.0,
     solvekwargs=(
         ftol=1e-7,
@@ -83,19 +83,19 @@ gr(size=(1200, 800))
 pager = PALEOmodel.PlotPager((1, 4), (legend_background_color=nothing, margin=(5, :mm)))
 
 solute_burial_flux=true
-plot_phi(run.output; colrange, pager)
-plot_w(run.output; colrange, pager)
-plot_biorates(run.output; colrange, pager)
-plot_Corg_O2(run.output; Corgs=["Corg",], colT=[first(tspan), last(tspan)], colrange, pager)
-plot_Corg_RCmultiG(run.output; Corg_indices=1:12, colrange, pager)
-plot_solutes(run.output; colT=[first(tspan), last(tspan)], solutes=["P", "DIC", "TAlk",  "SO4", "H2S", "CH4", ], colrange, pager)
-plot_budget(run.output; name="C", solids=["Corg", ], solutes=["DIC", "CH4"], solute_burial_flux, pager, colrange, fluxylims=(-4, 4), concxscale=:log10, concxlims=(1e-3, 1e4))
-plot_budget(run.output; name="P", solids=["Corg"], stoich_factors=Dict("Corg"=>1/106), solutes=["P"], solute_burial_flux, pager, colrange, concxscale=:log10, concxlims=(1e-3, 1e3))
-plot_budget(run.output; name="S", solids=[], solutes=["H2S", "SO4"], solute_burial_flux, pager, colrange, concxscale=:log10, concxlims=(1e-3, 1e4), fluxylims=(-1, 1) )
-plot_rates(run.output; colT=[first(tspan), last(tspan)], plot_freminOrgTot=false, remin_rates=["reminOrgOxO2", "reminOrgOxSO4", "reminOrgOxCH4"], colrange, pager)
-plot_conc_summary(run.output; species=["DIC", "O2", "P", "SO4", "H2S", "CH4"], pager, colrange, xscale=:log10, xlims=(1e-3, 1e2))
+plot_phi(paleorun.output; colrange, pager)
+plot_w(paleorun.output; colrange, pager)
+plot_biorates(paleorun.output; colrange, pager)
+plot_Corg_O2(paleorun.output; Corgs=["Corg",], colT=[first(tspan), last(tspan)], colrange, pager)
+plot_Corg_RCmultiG(paleorun.output; Corg_indices=1:12, colrange, pager)
+plot_solutes(paleorun.output; colT=[first(tspan), last(tspan)], solutes=["P", "DIC", "TAlk",  "SO4", "H2S", "CH4", ], colrange, pager)
+plot_budget(paleorun.output; name="C", solids=["Corg", ], solutes=["DIC", "CH4"], solute_burial_flux, pager, colrange, fluxylims=(-4, 4), concxscale=:log10, concxlims=(1e-3, 1e4))
+plot_budget(paleorun.output; name="P", solids=["Corg"], stoich_factors=Dict("Corg"=>1/106), solutes=["P"], solute_burial_flux, pager, colrange, concxscale=:log10, concxlims=(1e-3, 1e3))
+plot_budget(paleorun.output; name="S", solids=[], solutes=["H2S", "SO4"], solute_burial_flux, pager, colrange, concxscale=:log10, concxlims=(1e-3, 1e4), fluxylims=(-1, 1) )
+plot_rates(paleorun.output; colT=[first(tspan), last(tspan)], plot_freminOrgTot=false, remin_rates=["reminOrgOxO2", "reminOrgOxSO4", "reminOrgOxCH4"], colrange, pager)
+plot_conc_summary(paleorun.output; species=["DIC", "O2", "P", "SO4", "H2S", "CH4"], pager, colrange, xscale=:log10, xlims=(1e-3, 1e2))
 pager = PALEOmodel.PlotPager((2, 4), (legend_background_color=nothing, margin=(5, :mm)))
-plot_summary_stacked(run.output; species=["SO4", "CH4", "DIC", "P", "O2", "H2S"], plot_pHfree=false, pager, colrange)
+plot_summary_stacked(paleorun.output; species=["SO4", "CH4", "DIC", "P", "O2", "H2S"], plot_pHfree=false, pager, colrange)
 pager(:newpage)
 
 

--- a/examples/boudreau1996/PALEO_examples_sediment.jl
+++ b/examples/boudreau1996/PALEO_examples_sediment.jl
@@ -37,11 +37,11 @@ tspan=(0.0, 10000.0)
 
 initial_state, modeldata = PALEOmodel.initialize!(model)
 
-run = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())
+paleorun = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())
 
 # Newton, no line search
 # sol = PALEOmodel.SteadyState.steadystateForwardDiff(
-#     run, initial_state, modeldata, 0.0,
+#     paleorun, initial_state, modeldata, 0.0,
 #     solvekwargs=(
 #         ftol=5e-9,
 #         method=:newton,
@@ -54,7 +54,7 @@ run = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory
 # Bounds and max step size for Newton solve. NB some tracers start at zero so set newton_max_ratio=Inf
 newton_min, newton_max, newton_min_ratio, newton_max_ratio = 1e-80, Inf, 0.1, Inf 
 PALEOmodel.SteadyState.steadystate_ptcForwardDiff(
-    run, initial_state, modeldata, tspan, 1e-3,
+    paleorun, initial_state, modeldata, tspan, 1e-3,
     deltat_fac=2.0,
     solvekwargs=(
         ftol=1e-7,
@@ -80,8 +80,8 @@ config_sediment_expts(model,
 ) 
 tspan=(0,10000.0)
 initial_state, modeldata = PALEOmodel.initialize!(model)
-run = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())
-sol = PALEOmodel.ODE.integrateForwardDiff(run, initial_state, modeldata, tspan, 
+paleorun = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())
+sol = PALEOmodel.ODE.integrateForwardDiff(paleorun, initial_state, modeldata, tspan, 
 #    solvekwargs=(reltol=1e-3, abstol=1e-4*PALEOmodel.get_statevar_norm(modeldata.solver_view_all), maxiters=1000000, saveat=[0.0, 0.1, 1.0, 10.0, 1e2, 1e3, 1e4]))  # first run includes JIT time
 #    solvekwargs=(reltol=1e-3, abstol=1e-6*PALEOmodel.get_statevar_norm(modeldata.solver_view_all), maxiters=1000000, saveat=[0.0, 0.1, 1.0, 10.0, 1e2, 1e3, 1e4]))  # first run includes JIT time
     solvekwargs=(reltol=1e-5, abstol=1e-6*PALEOmodel.get_statevar_norm(modeldata.solver_view_all), maxiters=1000000, saveat=[0.0, 0.1, 1.0, 10.0, 1e2, 1e3, 1e4]))  # first run includes JIT time
@@ -89,11 +89,11 @@ sol = PALEOmodel.ODE.integrateForwardDiff(run, initial_state, modeldata, tspan,
 #    solvekwargs=(reltol=1e-9, abstol=1e-6*PALEOmodel.get_statevar_norm(modeldata.solver_view_all), maxiters=1000000, saveat=[0.0, 0.1, 1.0, 10.0, 1e2, 1e3, 1e4]))  # first run includes JIT time
 #    solvekwargs=(reltol=1e-11, abstol=1e-6*PALEOmodel.get_statevar_norm(modeldata.solver_view_all), maxiters=10000000, saveat=[0.0, 0.1, 1.0, 10.0, 1e2, 1e3, 1e4]))  # first run includes JIT time
 #    solvekwargs=(reltol=1e-13, abstol=1e-6*PALEOmodel.get_statevar_norm(modeldata.solver_view_all), maxiters=1000000, saveat=[0.0, 0.1, 1.0, 10.0, 1e2, 1e3, 1e4]))  # first run includes JIT time
-# sol = PALEOmodel.ODE.integrateDAEForwardDiff(run, initial_state, modeldata, tspan, solvekwargs=(reltol=1e-5,))  # first run includes JIT time
+# sol = PALEOmodel.ODE.integrateDAEForwardDiff(paleorun, initial_state, modeldata, tspan, solvekwargs=(reltol=1e-5,))  # first run includes JIT time
 
 # Test additional solver options
-# sol = PALEOmodel.ODE.integrateDAEForwardDiff(run, initial_state, modeldata, tspan, jac_ad=:ForwardDiff, alg=IDA(), solvekwargs=(reltol=1e-5,))
-# sol = PALEOmodel.ODE.integrate(run, initial_state, modeldata, tspan, solvekwargs=(reltol=1e-5,))  # first run includes JIT time
+# sol = PALEOmodel.ODE.integrateDAEForwardDiff(paleorun, initial_state, modeldata, tspan, jac_ad=:ForwardDiff, alg=IDA(), solvekwargs=(reltol=1e-5,))
+# sol = PALEOmodel.ODE.integrate(paleorun, initial_state, modeldata, tspan, solvekwargs=(reltol=1e-5,))  # first run includes JIT time
 =#
 
 
@@ -107,11 +107,11 @@ sol = PALEOmodel.ODE.integrateForwardDiff(run, initial_state, modeldata, tspan,
 
 # multiple plots per screen
 gr(size=(900, 600))
-pager = PALEOmodel.PlotPager((1,3), (legend_background_color=nothing, ))
+pager = PALEOmodel.PlotPager((1,3), (legend_background_color=nothing, margin=(5, :mm)))
 
-plot_Corg_O2(run.output, Corgs=["Corg1", "Corg2"], colT=[first(tspan), last(tspan)], pager=pager)
-plot_solutes(run.output, colT=[first(tspan), last(tspan)], pager=pager)
-plot_rates(run.output, colT=[first(tspan), last(tspan)], pager=pager)
+plot_Corg_O2(paleorun.output, Corgs=["Corg1", "Corg2"], colT=[first(tspan), last(tspan)], pager=pager)
+plot_solutes(paleorun.output, colT=[first(tspan), last(tspan)], pager=pager)
+plot_rates(paleorun.output, colT=[first(tspan), last(tspan)], pager=pager)
 
 pager(:newpage)
 

--- a/examples/boudreau1996/PALEO_examples_sediment_Sisotopes.jl
+++ b/examples/boudreau1996/PALEO_examples_sediment_Sisotopes.jl
@@ -38,14 +38,14 @@ tspan=(0.0, 10000.0)
 
 initial_state, modeldata = PALEOmodel.initialize!(model)
 
-run = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())
+paleorun = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())
 
 # PTC, Newton, no line search
 # TODO This form of Newton regularization doesn't work with isotopes !! (as isotope mol*delta state variables can be -ve)
 # Bounds and max step size for Newton solve. NB some tracers start at zero so set newton_max_ratio=Inf
 # newton_min, newton_max, newton_min_ratio, newton_max_ratio = 1e-80, Inf, 0.1, Inf 
 PALEOmodel.SteadyState.steadystate_ptcForwardDiff(
-    run, initial_state, modeldata, tspan, 1e-3,
+    paleorun, initial_state, modeldata, tspan, 1e-3,
     deltat_fac=2.0,
     solvekwargs=(
         ftol=1e-7,
@@ -71,12 +71,12 @@ PALEOmodel.SteadyState.steadystate_ptcForwardDiff(
 
 # multiple plots per screen
 gr(size=(900, 600))
-pager = PALEOmodel.PlotPager((1,3), (legend_background_color=nothing, ))
+pager = PALEOmodel.PlotPager((1,3), (legend_background_color=nothing, margin=(5, :mm)))
 
-plot_Corg_O2(run.output; Corgs=["Corg1", "Corg2"], colT=[first(tspan), last(tspan)], pager=pager)
-plot_solutes(run.output; colT=[first(tspan), last(tspan)], pager=pager)
-plot_solute_deltas(run.output; solutes=["SO4", "H2S"], colT=[first(tspan), last(tspan)], pager=pager)
-plot_rates(run.output; colT=[first(tspan), last(tspan)], pager=pager)
+plot_Corg_O2(paleorun.output; Corgs=["Corg1", "Corg2"], colT=[first(tspan), last(tspan)], pager=pager)
+plot_solutes(paleorun.output; colT=[first(tspan), last(tspan)], pager=pager)
+plot_solute_deltas(paleorun.output; solutes=["SO4", "H2S"], colT=[first(tspan), last(tspan)], pager=pager)
+plot_rates(paleorun.output; colT=[first(tspan), last(tspan)], pager=pager)
 
 pager(:newpage)
 

--- a/examples/boudreau1996/PALEO_examples_sediment_carb.jl
+++ b/examples/boudreau1996/PALEO_examples_sediment_carb.jl
@@ -35,14 +35,14 @@ tspan=(0.0, 10000.0)
 
 initial_state, modeldata = PALEOmodel.initialize!(model)
 
-run = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())
+paleorun = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())
 
 
 # PTC, Newton, no line search
 # Bounds and max step size for Newton solve. NB some tracers start at zero so set newton_max_ratio=Inf
 newton_min, newton_max, newton_min_ratio, newton_max_ratio = 1e-80, Inf, 0.1, Inf 
 PALEOmodel.SteadyState.steadystate_ptcForwardDiff(
-    run, initial_state, modeldata, tspan, 1e-3,
+    paleorun, initial_state, modeldata, tspan, 1e-3,
     deltat_fac=2.0,
     solvekwargs=(
         ftol=1e-7,
@@ -67,12 +67,12 @@ PALEOmodel.SteadyState.steadystate_ptcForwardDiff(
 
 # multiple plots per screen
 gr(size=(900, 600))
-pager = PALEOmodel.PlotPager((1,3), (legend_background_color=nothing, ))
+pager = PALEOmodel.PlotPager((1,3), (legend_background_color=nothing, margin=(5, :mm)))
 
-plot_Corg_O2(run.output; Corgs=["Corg1", "Corg2"], colT=[first(tspan), last(tspan)], pager)
-plot_solutes(run.output; solutes = ["P", "SO4", "H2S", "CH4", "DIC", "TAlk"], colT=[first(tspan), last(tspan)], pager)
-plot_rates(run.output; colT=[first(tspan), last(tspan)], pager=pager)
-plot_carbchem(run.output; include_constraint_error=true, colT=last(tspan), pager)
+plot_Corg_O2(paleorun.output; Corgs=["Corg1", "Corg2"], colT=[first(tspan), last(tspan)], pager)
+plot_solutes(paleorun.output; solutes = ["P", "SO4", "H2S", "CH4", "DIC", "TAlk"], colT=[first(tspan), last(tspan)], pager)
+plot_rates(paleorun.output; colT=[first(tspan), last(tspan)], pager=pager)
+plot_carbchem(paleorun.output; include_constraint_error=true, colT=last(tspan), pager)
 
 pager(:newpage)
 

--- a/examples/boudreau1996/PALEO_examples_sediment_cfg.yaml
+++ b/examples/boudreau1996/PALEO_examples_sediment_cfg.yaml
@@ -466,7 +466,7 @@ sediment_Corg_O2_carb:
                         R_conc:vphase:                  VP_Solute                    
                         R:initial_value:                1e-30  # concentration m-3 (1027 kg m-3 * 200e-6 mol/kg-sw)
                         R:norm_value:                   1000e-3                        
-                        R_conc:diffusivity_speciesname: Na # TODO - use major cations for molecular diffusivity
+                        R_conc:diffusivity_speciesname: HCO3 # TODO
                 
 
                 reservoir_Corg1:
@@ -512,17 +512,36 @@ sediment_Corg_O2_carb:
                     variable_attributes:
                         R_conc:initial_value: 70.17e-3   # mol m-3  70.17 uM modern F concentration
 
+                # [H+] primary species (as pHfree) for algebraic constraint on TAlk
+                TAlk_constraint_H_primary_species:
+                    class: ReactionConstraintReservoir
+                    variable_links:
+                        volume: volume_solute
+                        R*: TAlk*
+                        primary_volume: volume_solute
+                        Primary_pconc: pHfree
+                        Primary_conc: H_conc                        
+                    parameters:
+                        primary_total_stoich: 0.0 # ReactionCO2SYS adds H to TAlk_calc
+                        primary_variable: p_concentration # provide pHfree as state variable to solver
+                        constraint_variable: amount # provide TAlk_constraint (mol) as algebraic constraint to solver
+                    variable_attributes: 
+                        Primary_pconc%initial_value: 8.0
+                        Primary_pconc%norm_value: 1.0
+                        Primary_conc%advect: false
+                        R_constraint%norm_value: 1.0
+
                 carbchem:
                     class: ReactionCO2SYS
                     parameters:
                         components: ["Ci", "B", "S", "F", "Omega", "H2S"]
                         defaultconcs: [] # ["TF", "TB", "Ca"]
-                        solve_pH:   constraint # H as a state variable
-                        outputs:    ["H", "CO2", "HCO3", "CO3", "OmegaCA", "OmegaAR"]
+                        solve_pH:   speciationTAlk # accumulate TAlk contributions into TAlk_calc
+                        # H_conc primary species is defined by ReactionConstraintReservoir, but is still added to TAlk by ReactionCO2SYS
+                        outputs:    ["CO2", "HCO3", "CO3", "OmegaCA", "OmegaAR"]
                         
                     variable_links:
                         volume: volume_solute
-                        H: H_conc
                         TCi_conc: DIC_conc
                         TS_conc: SO4_conc
                         TH2S_conc: H2S_conc

--- a/examples/boudreau1996/PALEO_examples_sediment_x10.jl
+++ b/examples/boudreau1996/PALEO_examples_sediment_x10.jl
@@ -51,13 +51,13 @@ tspan=(0.0, 10000.0)
 
 initial_state, modeldata = PALEOmodel.initialize!(model)
 
-run = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())
+paleorun = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())
 
 # PTC, Newton, no line search
 # Bounds and max step size for Newton solve. NB some tracers start at zero so set newton_max_ratio=Inf
 newton_min, newton_max, newton_min_ratio, newton_max_ratio = 1e-80, Inf, 0.1, Inf 
 PALEOmodel.SteadyState.steadystate_ptcForwardDiff(
-    run, initial_state, modeldata, tspan, 1e-3,
+    paleorun, initial_state, modeldata, tspan, 1e-3,
     deltat_fac=2.0,
     solvekwargs=(
         ftol=1e-7,
@@ -85,25 +85,25 @@ gr(size=(1500, 900))
 pager = PALEOmodel.PlotPager((2,5), (legend_background_color=nothing, margin=(5, :mm)))
 
 colrange=1:10 # number of columns
-plot_Corg_O2(run.output; Corgs=["Corg1", "Corg2"], colT=[first(tspan), last(tspan)], colrange, pager=pager)
-plot_solutes(run.output; colT=[first(tspan), last(tspan)], colrange, pager=pager)
-plot_rates(run.output; colT=[first(tspan), last(tspan)], colrange, pager=pager)
+plot_Corg_O2(paleorun.output; Corgs=["Corg1", "Corg2"], colT=[first(tspan), last(tspan)], colrange, pager=pager)
+plot_solutes(paleorun.output; colT=[first(tspan), last(tspan)], colrange, pager=pager)
+plot_rates(paleorun.output; colT=[first(tspan), last(tspan)], colrange, pager=pager)
 
 pager(:newpage)
 
 
 # summary plots of solute fluxes vs O2_conc
-O2_conc = [PALEOmodel.get_array(run.output, "oceanfloor.O2_conc", (tmodel=1e12, cell=i)).values for i in 1:10]
-SO4_conc = [PALEOmodel.get_array(run.output, "oceanfloor.SO4_conc", (tmodel=1e12, cell=i)).values for i in 1:10]
-soluteflux_O2 = [PALEOmodel.get_array(run.output, "fluxOceanfloor.soluteflux_O2", (tmodel=1e12, cell=i)).values for i in 1:10]
-soluteflux_H2S = [PALEOmodel.get_array(run.output, "fluxOceanfloor.soluteflux_H2S", (tmodel=1e12, cell=i)).values for i in 1:10]
-soluteflux_CH4 = [PALEOmodel.get_array(run.output, "fluxOceanfloor.soluteflux_CH4", (tmodel=1e12, cell=i)).values for i in 1:10]
+O2_conc = [PALEOmodel.get_array(paleorun.output, "oceanfloor.O2_conc", (tmodel=1e12, cell=i)).values for i in 1:10]
+SO4_conc = [PALEOmodel.get_array(paleorun.output, "oceanfloor.SO4_conc", (tmodel=1e12, cell=i)).values for i in 1:10]
+soluteflux_O2 = [PALEOmodel.get_array(paleorun.output, "fluxOceanfloor.soluteflux_O2", (tmodel=1e12, cell=i)).values for i in 1:10]
+soluteflux_H2S = [PALEOmodel.get_array(paleorun.output, "fluxOceanfloor.soluteflux_H2S", (tmodel=1e12, cell=i)).values for i in 1:10]
+soluteflux_CH4 = [PALEOmodel.get_array(paleorun.output, "fluxOceanfloor.soluteflux_CH4", (tmodel=1e12, cell=i)).values for i in 1:10]
 
-reminOrgOxO2_total = [sum(PALEOmodel.get_array(run.output, "sediment.reminOrgOxO2", (tmodel=1e12, column=i)).values) for i in 1:10]
-reminOrgOxSO4_total = [sum(PALEOmodel.get_array(run.output, "sediment.reminOrgOxSO4", (tmodel=1e12, column=i)).values) for i in 1:10]
-reminOrgOxCH4_total = [sum(PALEOmodel.get_array(run.output, "sediment.reminOrgOxCH4", (tmodel=1e12, column=i)).values) for i in 1:10]
+reminOrgOxO2_total = [sum(PALEOmodel.get_array(paleorun.output, "sediment.reminOrgOxO2", (tmodel=1e12, column=i)).values) for i in 1:10]
+reminOrgOxSO4_total = [sum(PALEOmodel.get_array(paleorun.output, "sediment.reminOrgOxSO4", (tmodel=1e12, column=i)).values) for i in 1:10]
+reminOrgOxCH4_total = [sum(PALEOmodel.get_array(paleorun.output, "sediment.reminOrgOxCH4", (tmodel=1e12, column=i)).values) for i in 1:10]
 
-redox_H2S_O2_total = [sum(PALEOmodel.get_array(run.output, "sediment.redox_H2S_O2", (tmodel=1e12, column=i)).values) for i in 1:10]
+redox_H2S_O2_total = [sum(PALEOmodel.get_array(paleorun.output, "sediment.redox_H2S_O2", (tmodel=1e12, column=i)).values) for i in 1:10]
 
 gr(size=(800, 600))
 pager = PALEOmodel.PlotPager((2,2), (legend_background_color=nothing, margin=(5, :mm)))

--- a/examples/boudreau1996/README.md
+++ b/examples/boudreau1996/README.md
@@ -45,11 +45,11 @@ Three sediment column example as `PALEO_examples_sediment.jl`, with carbonate ch
 
 NB: POC includes C, P only (no N) to simplify TAlk conservation check (where `soluteflux_TAlk = 2*soluteflux_H2S`)
 
-    julia> PALEOmodel.get_array(run.output, "fluxOceanfloor.soluteflux_TAlk", (cell=1, tmodel=1e12)).values
+    julia> PALEOmodel.get_array(paleorun.output, "fluxOceanfloor.soluteflux_TAlk", (cell=1, tmodel=1e12)).values
     0.014436958064622729
 
-    julia> PALEOmodel.get_array(run.output, "fluxOceanfloor.soluteflux_H2S", (cell=1, tmodel=1e12)).values
+    julia> PALEOmodel.get_array(paleorun.output, "fluxOceanfloor.soluteflux_H2S", (cell=1, tmodel=1e12)).values
     0.007218479032309767
 
-    julia> PALEOmodel.get_array(run.output, "fluxOceanfloor.soluteflux_SO4", (cell=1, tmodel=1e12)).values
+    julia> PALEOmodel.get_array(paleorun.output, "fluxOceanfloor.soluteflux_SO4", (cell=1, tmodel=1e12)).values
     -0.0072184790322306815

--- a/examples/boudreau1996/runtests.jl
+++ b/examples/boudreau1996/runtests.jl
@@ -34,11 +34,11 @@ skipped_testsets = [
 
     tspan=(0,10000.0)
     initial_state, modeldata = PALEOmodel.initialize!(model)
-    run = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())
+    paleorun = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())
 
     # Newton, no(?) line search
     sol = PALEOmodel.SteadyState.steadystateForwardDiff(
-        run, initial_state, modeldata, 0.0;
+        paleorun, initial_state, modeldata, 0.0;
         solvekwargs=(
             ftol=10e-9,
             # ftol=5e-5,
@@ -53,7 +53,7 @@ skipped_testsets = [
     println("conservation checks:")
     conschecks = [ ]    
     for (domname, varname, rtol) in conschecks
-        startval, endval = PB.get_data(run.output, domname*"."*varname)[[1, end]]
+        startval, endval = PB.get_data(paleorun.output, domname*"."*varname)[[1, end]]
         println("  check $domname.$varname $startval $endval $rtol")
         @test isapprox(startval, endval, rtol=rtol)
     end
@@ -66,7 +66,7 @@ skipped_testsets = [
         ("fluxOceanfloor", "soluteflux_H2S", [0.025073, 6.8626e-5, 0.00088524],   2.5e-2),
     ]    
     for (domname, varname, checkval, rtol) in checkvals
-        outputval = PB.get_data(run.output, domname*"."*varname)[end]
+        outputval = PB.get_data(paleorun.output, domname*"."*varname)[end]
         println("  check $domname.$varname $outputval $checkval $rtol")
         @test isapprox(outputval, checkval, rtol=rtol)
     end

--- a/examples/ironsulphur/PALEO_examples_sediment_Fe.jl
+++ b/examples/ironsulphur/PALEO_examples_sediment_Fe.jl
@@ -37,13 +37,13 @@ tspan=(0.0, 1e6)
 
 initial_state, modeldata = PALEOmodel.initialize!(model)
 
-run = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())
+paleorun = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())
 
 # PTC, Newton, no line search
 # Bounds and max step size for Newton solve. NB some tracers start at zero so set newton_max_ratio=Inf
 newton_min, newton_max, newton_min_ratio, newton_max_ratio = 1e-80, Inf, 0.1, Inf 
 PALEOmodel.SteadyState.steadystate_ptcForwardDiff(
-    run, initial_state, modeldata, tspan, 1e-3,
+    paleorun, initial_state, modeldata, tspan, 1e-3,
     deltat_fac=2.0,
     solvekwargs=(
         ftol=1e-7,
@@ -73,17 +73,17 @@ pager = PALEOmodel.PlotPager((1,3), (legend_background_color=nothing, margin=(5,
 colrange=1:3
 
 plot_budgets(
-    run.output;
+    paleorun.output;
     budgets="budgets.net_input_".*["C", "P", "S", "Fe", "TAlk"],
     ylims=(-1e-6, 1e-6),
     pager, colrange,
 )
 pager(:newpage)
 
-plot_Corg_O2(run.output; Corgs=["Corg1", "Corg2"], colT=[first(tspan), last(tspan)], colrange, pager)
-plot_solutes(run.output; colT=[first(tspan), last(tspan)], solutes=["P", "SO4", "H2S", "CH4", "FeII"], colrange, pager)
-plot_solids(run.output; colT=[first(tspan), last(tspan)], solids=["FeHR", "FeMR", "FePR"], colrange, pager)
-plot_rates(run.output; colT=[first(tspan), last(tspan)], remin_rates=["reminOrgOxO2", "reminOrgOxFeIIIOx", "reminOrgOxSO4", "reminOrgOxCH4"], colrange, pager)
+plot_Corg_O2(paleorun.output; Corgs=["Corg1", "Corg2"], colT=[first(tspan), last(tspan)], colrange, pager)
+plot_solutes(paleorun.output; colT=[first(tspan), last(tspan)], solutes=["P", "SO4", "H2S", "CH4", "FeII"], colrange, pager)
+plot_solids(paleorun.output; colT=[first(tspan), last(tspan)], solids=["FeHR", "FeMR", "FePR"], colrange, pager)
+plot_rates(paleorun.output; colT=[first(tspan), last(tspan)], remin_rates=["reminOrgOxO2", "reminOrgOxFeIIIOx", "reminOrgOxSO4", "reminOrgOxCH4"], colrange, pager)
 
 pager(:newpage)
 

--- a/examples/ironsulphur/PALEO_examples_sediment_Fe_pyr.jl
+++ b/examples/ironsulphur/PALEO_examples_sediment_Fe_pyr.jl
@@ -48,14 +48,14 @@ tspan=(0.0, 100000.0)
 
 initial_state, modeldata = PALEOmodel.initialize!(model)
 
-run = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())
+paleorun = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())
 
 # PTC, Newton, no line search
 # Bounds and max step size for Newton solve. NB requires min/max ratio for robustness so check all tracers initial_value is not zero
 # newton_min, newton_max, newton_min_ratio, newton_max_ratio = 1e-80, 1e6, 0.1, 10.0
 newton_min, newton_max, newton_min_ratio, newton_max_ratio = 1e-30, 1e6, 1e-2, 1e2
 PALEOmodel.SteadyState.steadystate_ptcForwardDiff(
-    run, initial_state, modeldata, tspan, 1e-3,
+    paleorun, initial_state, modeldata, tspan, 1e-3,
     deltat_fac=2.0,
     solvekwargs=(
         ftol=1e-7,
@@ -85,12 +85,12 @@ PALEOmodel.SteadyState.steadystate_ptcForwardDiff(
 gr(size=(900, 600))
 pager = PALEOmodel.PlotPager((1,3), (legend_background_color=nothing, margin=(5, :mm)))
 
-plot_Corg_O2(run.output; Corgs=["Corg1", "Corg2"], colT=[first(tspan), last(tspan)], pager=pager)
-plot_solutes(run.output; colT=[first(tspan), last(tspan)], solutes=["P", "SO4", "TH2S", "CH4", "H2", "TFeII", "DIC", "TAlk"], pager=pager)
-plot_sediment_FeS_summary(run.output; FeII_species = ["TFeII", "FeII", "FeSaq",], pager=pager)
-plot_solids(run.output; colT=[first(tspan), last(tspan)], solids=["FeHR", "FeMR", "FePR", "FeSm", "FeS2pyr"], pager=pager)
-plot_rates(run.output; colT=[first(tspan), last(tspan)], remin_rates=["reminOrgOxO2", "reminOrgOxFeIIIOx", "reminOrgOxSO4", "reminOrgOxCH4"], pager=pager)
-plot_carbchem(run.output; include_constraint_error=true, colT=last(tspan), pager)
+plot_Corg_O2(paleorun.output; Corgs=["Corg1", "Corg2"], colT=[first(tspan), last(tspan)], pager=pager)
+plot_solutes(paleorun.output; colT=[first(tspan), last(tspan)], solutes=["P", "SO4", "TH2S", "CH4", "H2", "TFeII", "DIC", "TAlk"], pager=pager)
+plot_sediment_FeS_summary(paleorun.output; FeII_species = ["TFeII", "FeII", "FeSaq",], pager=pager)
+plot_solids(paleorun.output; colT=[first(tspan), last(tspan)], solids=["FeHR", "FeMR", "FePR", "FeSm", "FeS2pyr"], pager=pager)
+plot_rates(paleorun.output; colT=[first(tspan), last(tspan)], remin_rates=["reminOrgOxO2", "reminOrgOxFeIIIOx", "reminOrgOxSO4", "reminOrgOxCH4"], pager=pager)
+plot_carbchem(paleorun.output; include_constraint_error=true, colT=last(tspan), pager)
 
 pager(:newpage)
 

--- a/examples/ironsulphur/PALEO_examples_sediment_Fe_pyr_x15.jl
+++ b/examples/ironsulphur/PALEO_examples_sediment_Fe_pyr_x15.jl
@@ -101,14 +101,14 @@ tspan=(0.0, 10000.0)
 
 initial_state, modeldata = PALEOmodel.initialize!(model)
 
-run = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())
+paleorun = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())
 
 # PTC, Newton, no line search
 # Bounds and max step size for Newton solve. NB requires min/max ratio for robustness so check all tracers initial_value is not zero
 # newton_min, newton_max, newton_min_ratio, newton_max_ratio = 1e-80, 1e6, 0.1, 10.0
 newton_min, newton_max, newton_min_ratio, newton_max_ratio = 1e-30, 1e6, 1e-2, 1e2
 PALEOmodel.SteadyState.steadystate_ptcForwardDiff(
-    run, initial_state, modeldata, tspan, 1e-3,
+    paleorun, initial_state, modeldata, tspan, 1e-3,
     deltat_fac=2.0,
     solvekwargs=(
         ftol=1e-3,
@@ -141,36 +141,36 @@ pager = PALEOmodel.PlotPager((3,5), (legend_background_color=nothing, margin=(5,
 colrange=1:num_columns # number of columns
 
 # check numerics: DAE constraint variables ~0
-#  plot_tracers(run.output; colT=[1.0, last(tspan)], tracers=["SmIIaqtot_constraint", "FeIIaqtot_constraint"], colrange, pager=pager)
+#  plot_tracers(paleorun.output; colT=[1.0, last(tspan)], tracers=["SmIIaqtot_constraint", "FeIIaqtot_constraint"], colrange, pager=pager)
 
-plot_Corg_O2(run.output; Corgs=["Corg1", "Corg2"], colT=[first(tspan), last(tspan)], colrange, pager)
-plot_solutes(run.output; colT=[first(tspan), last(tspan)], solutes=["P", "DIC", "TAlk", "SO4", "TH2S", "CH4", "H2", "TFeII"], colrange, pager)
-plot_sediment_FeS_summary(run.output; FeII_species = ["TFeII", "FeII", "FeSaq",], colrange, pager)
-plot_solids(run.output; colT=[first(tspan), last(tspan)], solids=["FeHR", "FeMR", "FePR", "FeSm", "FeS2pyr"], colrange, pager)
-plot_rates(run.output; colT=[first(tspan), last(tspan)], remin_rates=["reminOrgOxO2", "reminOrgOxFeIIIOx", "reminOrgOxSO4", "reminOrgOxCH4"], colrange, pager)
-plot_carbchem(run.output; include_constraint_error=true, colT=last(tspan), colrange, pager)
+plot_Corg_O2(paleorun.output; Corgs=["Corg1", "Corg2"], colT=[first(tspan), last(tspan)], colrange, pager)
+plot_solutes(paleorun.output; colT=[first(tspan), last(tspan)], solutes=["P", "DIC", "TAlk", "SO4", "TH2S", "CH4", "H2", "TFeII"], colrange, pager)
+plot_sediment_FeS_summary(paleorun.output; FeII_species = ["TFeII", "FeII", "FeSaq",], colrange, pager)
+plot_solids(paleorun.output; colT=[first(tspan), last(tspan)], solids=["FeHR", "FeMR", "FePR", "FeSm", "FeS2pyr"], colrange, pager)
+plot_rates(paleorun.output; colT=[first(tspan), last(tspan)], remin_rates=["reminOrgOxO2", "reminOrgOxFeIIIOx", "reminOrgOxSO4", "reminOrgOxCH4"], colrange, pager)
+plot_carbchem(paleorun.output; include_constraint_error=true, colT=last(tspan), colrange, pager)
 
 pager(:newpage)
 
 
 # summary plots of solute fluxes vs O2_conc
-O2_conc = [PALEOmodel.get_array(run.output, "oceanfloor.O2_conc", (tmodel=1e12, cell=i)).values for i in 1:num_columns]
-SO4_conc = [PALEOmodel.get_array(run.output, "oceanfloor.SO4_conc", (tmodel=1e12, cell=i)).values for i in 1:num_columns]
-soluteflux_O2 = [PALEOmodel.get_array(run.output, "fluxOceanfloor.soluteflux_O2", (tmodel=1e12, cell=i)).values for i in 1:num_columns]
-soluteflux_TFeII = [PALEOmodel.get_array(run.output, "fluxOceanfloor.soluteflux_TFeII", (tmodel=1e12, cell=i)).values for i in 1:num_columns]
-soluteflux_TH2S = [PALEOmodel.get_array(run.output, "fluxOceanfloor.soluteflux_TH2S", (tmodel=1e12, cell=i)).values for i in 1:num_columns]
-soluteflux_CH4 = [PALEOmodel.get_array(run.output, "fluxOceanfloor.soluteflux_CH4", (tmodel=1e12, cell=i)).values for i in 1:num_columns]
+O2_conc = [PALEOmodel.get_array(paleorun.output, "oceanfloor.O2_conc", (tmodel=1e12, cell=i)).values for i in 1:num_columns]
+SO4_conc = [PALEOmodel.get_array(paleorun.output, "oceanfloor.SO4_conc", (tmodel=1e12, cell=i)).values for i in 1:num_columns]
+soluteflux_O2 = [PALEOmodel.get_array(paleorun.output, "fluxOceanfloor.soluteflux_O2", (tmodel=1e12, cell=i)).values for i in 1:num_columns]
+soluteflux_TFeII = [PALEOmodel.get_array(paleorun.output, "fluxOceanfloor.soluteflux_TFeII", (tmodel=1e12, cell=i)).values for i in 1:num_columns]
+soluteflux_TH2S = [PALEOmodel.get_array(paleorun.output, "fluxOceanfloor.soluteflux_TH2S", (tmodel=1e12, cell=i)).values for i in 1:num_columns]
+soluteflux_CH4 = [PALEOmodel.get_array(paleorun.output, "fluxOceanfloor.soluteflux_CH4", (tmodel=1e12, cell=i)).values for i in 1:num_columns]
 
-reminOrgOxO2_total = [sum(PALEOmodel.get_array(run.output, "sediment.reminOrgOxO2", (tmodel=1e12, column=i)).values) for i in 1:num_columns]
-reminOrgOxFeIIIox_total = [sum(PALEOmodel.get_array(run.output, "sediment.reminOrgOxFeIIIOx", (tmodel=1e12, column=i)).values) for i in 1:num_columns]
-reminOrgOxSO4_total = [sum(PALEOmodel.get_array(run.output, "sediment.reminOrgOxSO4", (tmodel=1e12, column=i)).values) for i in 1:num_columns]
-reminOrgOxCH4_total = [sum(PALEOmodel.get_array(run.output, "sediment.reminOrgOxCH4", (tmodel=1e12, column=i)).values) for i in 1:num_columns]
+reminOrgOxO2_total = [sum(PALEOmodel.get_array(paleorun.output, "sediment.reminOrgOxO2", (tmodel=1e12, column=i)).values) for i in 1:num_columns]
+reminOrgOxFeIIIox_total = [sum(PALEOmodel.get_array(paleorun.output, "sediment.reminOrgOxFeIIIOx", (tmodel=1e12, column=i)).values) for i in 1:num_columns]
+reminOrgOxSO4_total = [sum(PALEOmodel.get_array(paleorun.output, "sediment.reminOrgOxSO4", (tmodel=1e12, column=i)).values) for i in 1:num_columns]
+reminOrgOxCH4_total = [sum(PALEOmodel.get_array(paleorun.output, "sediment.reminOrgOxCH4", (tmodel=1e12, column=i)).values) for i in 1:num_columns]
 
-redox_H2S_O2_total = [sum(PALEOmodel.get_array(run.output, "sediment.redox_O2_TH2S_SO4", (tmodel=1e12, column=i)).values) for i in 1:num_columns]
-redox_CH4_SO4_total = [sum(PALEOmodel.get_array(run.output, "sediment.redox_CH4_SO4_DIC_TH2S", (tmodel=1e12, column=i)).values) for i in 1:num_columns]
+redox_H2S_O2_total = [sum(PALEOmodel.get_array(paleorun.output, "sediment.redox_O2_TH2S_SO4", (tmodel=1e12, column=i)).values) for i in 1:num_columns]
+redox_CH4_SO4_total = [sum(PALEOmodel.get_array(paleorun.output, "sediment.redox_CH4_SO4_DIC_TH2S", (tmodel=1e12, column=i)).values) for i in 1:num_columns]
 
 # burial fluxes
-burial_FeS2pyr = [sum(PALEOmodel.get_array(run.output, "fluxOceanBurial.flux_FeS2pyr", (tmodel=1e12, cell=i)).values) for i in 1:num_columns]
+burial_FeS2pyr = [sum(PALEOmodel.get_array(paleorun.output, "fluxOceanBurial.flux_FeS2pyr", (tmodel=1e12, cell=i)).values) for i in 1:num_columns]
 
 
 
@@ -186,7 +186,7 @@ column_ids = [
 ]
 
 for (crange, xvar, titlesuffix, xlabel) in column_ids  
-    p = plot(title="solute fluxes, $titlesuffix", xlabel=xlabel, ylabel="flux (mol m-2 yr-1)", ylim=(-2.0, 1.0), xflip=true)
+    local p = plot(title="solute fluxes, $titlesuffix", xlabel=xlabel, ylabel="flux (mol m-2 yr-1)", ylim=(-2.0, 1.0), xflip=true)
     plot!(p, xvar[crange], soluteflux_O2[crange]; label="O2")
     plot!(p, xvar[crange], soluteflux_TFeII[crange]; label="FeII")
     plot!(p, xvar[crange], soluteflux_TH2S[crange]; label="H2S")
@@ -196,7 +196,7 @@ for (crange, xvar, titlesuffix, xlabel) in column_ids
 end
 
 for (crange, xvar, titlesuffix, xlabel) in column_ids  
-    p = plot(title="remin fluxes, $titlesuffix", xlabel=xlabel, ylabel="flux (mol O2eq m-2 yr-1)", ylim=(-2.0, 1.0), xflip=true);
+    local p = plot(title="remin fluxes, $titlesuffix", xlabel=xlabel, ylabel="flux (mol O2eq m-2 yr-1)", ylim=(-2.0, 1.0), xflip=true);
     plot!(p, xvar[crange], reminOrgOxO2_total[crange]; label="O2")
     plot!(p, xvar[crange], reminOrgOxFeIIIox_total[crange]; label="FeIII")
     plot!(p, xvar[crange], reminOrgOxSO4_total[crange]; label="SO4")
@@ -206,7 +206,7 @@ for (crange, xvar, titlesuffix, xlabel) in column_ids
 end
    
 for (crange, xvar, titlesuffix, xlabel) in column_ids   
-    p = plot(title="H2S fluxes, $titlesuffix", xlabel=xlabel, ylabel="flux (mol S m-2 yr-1)", ylim=(-1.0, 1.0), xflip=true);
+    local p = plot(title="H2S fluxes, $titlesuffix", xlabel=xlabel, ylabel="flux (mol S m-2 yr-1)", ylim=(-1.0, 1.0), xflip=true);
     plot!(p, xvar[crange], -0.5.*reminOrgOxSO4_total[crange]; label="remin SO4");
     plot!(p, xvar[crange], redox_CH4_SO4_total[crange]; label="CH4 + SO4 -> H2S");
     plot!(p, xvar[crange], -1.0.*soluteflux_TH2S[crange]; label="solute H2S");
@@ -215,7 +215,7 @@ for (crange, xvar, titlesuffix, xlabel) in column_ids
 end
 
 for (crange, xvar, titlesuffix, xlabel) in column_ids 
-    p = plot(title="x = S-II buried / SR, $titlesuffix", xlabel=xlabel, ylabel="x = S-II buried / SR", ylim=(0, 1.0), xflip=true);
+    local p = plot(title="x = S-II buried / SR, $titlesuffix", xlabel=xlabel, ylabel="x = S-II buried / SR", ylim=(0, 1.0), xflip=true);
     plot!(p,xvar[crange], (2.0.*burial_FeS2pyr[crange]) ./ (-0.5.*reminOrgOxSO4_total[crange]) ; label="x");
     pager(p)
 end

--- a/examples/ironsulphur/README.md
+++ b/examples/ironsulphur/README.md
@@ -78,16 +78,16 @@ POC stoichiometry Corg, P only (no N) to simplify test of alkalinity budget, ie
 check alkalinity flux from SO4 and FeII solute fluxes = soluteflux_TAlk (as solid phase inputs and
 output make no contribution to alkalinity budget).
 
-    julia> PALEOmodel.get_array(run.output, "fluxOceanfloor.soluteflux_SmIIaqtot", (cell=1, tmodel=1e12)).values
+    julia> PALEOmodel.get_array(paleorun.output, "fluxOceanfloor.soluteflux_SmIIaqtot", (cell=1, tmodel=1e12)).values
     0.00021099944013347013
 
-    julia> PALEOmodel.get_array(run.output, "fluxOceanfloor.soluteflux_SO4", (cell=1, tmodel=1e12)).values
+    julia> PALEOmodel.get_array(paleorun.output, "fluxOceanfloor.soluteflux_SO4", (cell=1, tmodel=1e12)).values
     -0.0745449641168272  # net sulphate input balanced by FeS / FeS2 burial
 
-    julia> PALEOmodel.get_array(run.output, "fluxOceanfloor.soluteflux_FeIIaqtot", (cell=1, tmodel=1e12)).values
+    julia> PALEOmodel.get_array(paleorun.output, "fluxOceanfloor.soluteflux_FeIIaqtot", (cell=1, tmodel=1e12)).values
     0.0012053409002682764
 
-    julia> PALEOmodel.get_array(run.output, "fluxOceanfloor.soluteflux_TAlk", (cell=1, tmodel=1e12)).values
+    julia> PALEOmodel.get_array(paleorun.output, "fluxOceanfloor.soluteflux_TAlk", (cell=1, tmodel=1e12)).values
     0.15150061203704088
 
     julia> -2*-0.0745449641168272 + 2*0.0012053409002682764

--- a/examples/transport_tests/PALEO_transport_RCmultiG.jl
+++ b/examples/transport_tests/PALEO_transport_RCmultiG.jl
@@ -32,14 +32,14 @@ toutput=[0.0, 1e-1, 1e0, 1e1, 1e2, 1e3, 1e4, 1e5]
 
 initial_state, modeldata = PALEOmodel.initialize!(model)
 
-run = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())
+paleorun = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())
 
 # PTC, Newton, no line search
 # Bounds and max step size for Newton solve. NB some tracers start at zero so set newton_max_ratio=Inf
 # TODO isotope mol*delta can be -ve so can't use StepClampMultAll! for Newton robustness 
 # newton_min, newton_max, newton_min_ratio, newton_max_ratio = 1e-80, Inf, 0.1, Inf 
 PALEOmodel.SteadyState.steadystate_ptcForwardDiff(
-    run, initial_state, modeldata, tspan, 1e-3;
+    paleorun, initial_state, modeldata, tspan, 1e-3;
     deltat_fac=2.0,
     tss_output=toutput,
     solvekwargs=(
@@ -66,17 +66,17 @@ PALEOmodel.SteadyState.steadystate_ptcForwardDiff(
 
 # multiple plots per screen
 gr(size=(1200, 800))
-pager = PALEOmodel.PlotPager((1,4), (legend_background_color=nothing, ))
+pager = PALEOmodel.PlotPager((1,4), (legend_background_color=nothing, margin=(5, :mm)))
 colrange=1:4 # number of columns
 
-plot_phi(run.output; colrange, pager)
-plot_w(run.output; colrange, pager)
-plot_biorates(run.output; colrange, pager)
-plot_Corg_O2(run.output, Corgs=["Corg"]; colT=toutput, colrange, pager)
-plot_solutes(run.output; solutes=["DIC"], colT=toutput, colrange, pager)
-plot_solid_deltas(run.output; solids=["Corg"], colT=toutput, colrange, pager)
-plot_solute_deltas(run.output; solutes=["DIC"], colT=toutput, colrange, pager)
-plot_Corg_RCmultiG(run.output; colrange, pager)
+plot_phi(paleorun.output; colrange, pager)
+plot_w(paleorun.output; colrange, pager)
+plot_biorates(paleorun.output; colrange, pager)
+plot_Corg_O2(paleorun.output, Corgs=["Corg"]; colT=toutput, colrange, pager)
+plot_solutes(paleorun.output; solutes=["DIC"], colT=toutput, colrange, pager)
+plot_solid_deltas(paleorun.output; solids=["Corg"], colT=toutput, colrange, pager)
+plot_solute_deltas(paleorun.output; solutes=["DIC"], colT=toutput, colrange, pager)
+plot_Corg_RCmultiG(paleorun.output; colrange, pager)
 
 pager(:newpage)
 

--- a/examples/transport_tests/PALEO_transport_sediment.jl
+++ b/examples/transport_tests/PALEO_transport_sediment.jl
@@ -31,13 +31,13 @@ toutput=[0.0, 1e-1, 1e0, 1e1, 1e2, 1e3, 1e4]
 
 initial_state, modeldata = PALEOmodel.initialize!(model)
 
-run = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())
+paleorun = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())
 
 # PTC, Newton, no line search
 # Bounds and max step size for Newton solve. NB some tracers start at zero so set newton_max_ratio=Inf
 newton_min, newton_max, newton_min_ratio, newton_max_ratio = 1e-80, Inf, 0.1, Inf 
 PALEOmodel.SteadyState.steadystate_ptcForwardDiff(
-    run, initial_state, modeldata, tspan, 1e-3;
+    paleorun, initial_state, modeldata, tspan, 1e-3;
     deltat_fac=2.0,
     tss_output=toutput,
     solvekwargs=(
@@ -63,10 +63,10 @@ PALEOmodel.SteadyState.steadystate_ptcForwardDiff(
 
 # multiple plots per screen
 gr(size=(900, 600))
-pager = PALEOmodel.PlotPager((1,3), (legend_background_color=nothing, ))
+pager = PALEOmodel.PlotPager((1,3), (legend_background_color=nothing, margin=(5, :mm)))
 
-plot_w(run.output; pager=pager)
-plot_Corg_O2(run.output, Corgs=["Corg"]; colT=toutput, pager=pager)
+plot_w(paleorun.output; pager=pager)
+plot_Corg_O2(paleorun.output, Corgs=["Corg"]; colT=toutput, pager=pager)
 
 pager(:newpage)
 


### PR DESCRIPTION
- use 'paleorun' instead of 'run' in scripts, to avoid possible problems as 'run' is a Julia function name
- bugfix for 'boundreau1996/PALEO_examples_sediment_carb.jl'