### PR TITLE
Fix misleading comments on how to use a numerical value for species diffusivity

### DIFF
--- a/examples/transport_tests/PALEO_transport_Corgdecay_cfg.yaml
+++ b/examples/transport_tests/PALEO_transport_Corgdecay_cfg.yaml
@@ -126,7 +126,7 @@ sediment_abiotic_O2:
                         R_conc:vphase:                  VP_Solute                    
                         R_conc:initial_value:                0.0  # concentration m-3 (1027 kg m-3 * 200e-6 mol/kg-sw)
                         R_conc:norm_value:                   200e-3                        
-                        R_conc:diffusivity_speciesname: O2 # 2e-5 # cm^2/s approx constant
+                        R_conc:diffusivity_speciesname: O2 # "2e-5" # cm^2/s approx constant
                         # R_conc:gamma:                   0.5 # test value for reading bioirrigation coeff (O2 should usually be 1.0)
 
                 # passive "mud" solid phase

--- a/examples/transport_tests/PALEO_transport_RCmultiG_cfg.yaml
+++ b/examples/transport_tests/PALEO_transport_RCmultiG_cfg.yaml
@@ -157,7 +157,7 @@ sediment_abiotic_O2:
                         R_conc:vphase:                  VP_Solute                    
                         R:initial_value:                0.0  # concentration m-3 (1027 kg m-3 * 200e-6 mol/kg-sw)
                         R:norm_value:                   200e-3                        
-                        R_conc:diffusivity_speciesname: O2 # 2e-5 # (cm^2/s) approx constant
+                        R_conc:diffusivity_speciesname: O2 # "2e-5" # (cm^2/s) approx constant
 
                 reservoir_DIC:
                     class: ReactionReservoirTotal

--- a/examples/transport_tests/PALEO_transport_mudCorg_cfg.yaml
+++ b/examples/transport_tests/PALEO_transport_mudCorg_cfg.yaml
@@ -133,7 +133,7 @@ sediment_abiotic_O2:
                         R_conc:vphase:                  VP_Solute                    
                         R_conc:initial_value:                0.0  # concentration m-3 (1027 kg m-3 * 200e-6 mol/kg-sw)
                         R_conc:norm_value:                   200e-3                        
-                        R_conc:diffusivity_speciesname: O2 # 2e-5 # cm^2/s approx constant
+                        R_conc:diffusivity_speciesname: O2 # "2e-5" # cm^2/s approx constant
                         # R_conc:gamma:                   0.5 # test value for reading bioirrigation coeff (O2 should usually be 1.0)
 
                 # passive "mud" solid phase

--- a/examples/transport_tests/PALEO_transport_mud_cfg.yaml
+++ b/examples/transport_tests/PALEO_transport_mud_cfg.yaml
@@ -133,7 +133,7 @@ sediment_abiotic_O2:
                         R_conc:vphase:                  VP_Solute                    
                         R_conc:initial_value:                0.0  # concentration m-3 (1027 kg m-3 * 200e-6 mol/kg-sw)
                         R_conc:norm_value:                   200e-3                        
-                        R_conc:diffusivity_speciesname: O2 # 2e-5 # cm^2/s approx constant
+                        R_conc:diffusivity_speciesname: O2 # "2e-5" # cm^2/s approx constant
                         # R_conc:gamma:                   0.5 # test value for reading bioirrigation coeff (O2 should usually be 1.0)
 
                 # passive "mud" solid phase

--- a/examples/transport_tests/PALEO_transport_sediment_cfg.yaml
+++ b/examples/transport_tests/PALEO_transport_sediment_cfg.yaml
@@ -132,7 +132,7 @@ sediment_abiotic_O2:
                         R_conc:vphase:                  VP_Solute                    
                         R_conc:initial_value:                0.0  # concentration m-3 (1027 kg m-3 * 200e-6 mol/kg-sw)
                         R_conc:norm_value:                   200e-3                        
-                        R_conc:diffusivity_speciesname: O2 # 2e-5 # cm^2/s approx constant
+                        R_conc:diffusivity_speciesname: O2 # "2e-5" # cm^2/s approx constant
                         # R_conc:gamma:                   0.5 # test value for reading bioirrigation coeff (O2 should usually be 1.0)
 
                 reservoir_Corg:


### PR DESCRIPTION
Species diffusivity is defined by the 'diffusivity_speciesname' attribute on ReactionReservoir concentration variables, eg in the yaml:

                reservoir_O2:
                    class: ReactionReservoirTotal
                    parameters:
                        state_conc: true
                    variable_links:
                        R*:                             O2*
                        volume:                         volume_solute
                    variable_attributes:
                        R_conc:vphase:                  VP_Solute
                        R_conc:initial_value:                0.0  # concentration m-3 (1027 kg m-3 * 200e-6 mol/kg-sw)
                        R_conc:norm_value:                   200e-3
                        R_conc:diffusivity_speciesname: O2 # "2e-5" # cm^2/s approx constant
                        # R_conc:gamma:                   0.5 # test value for reading bioirrigation coeff (O2 should usually be 1.0)

This can either be:
  - a species name eg O2, in which case the empirical value is looked up in a table (and accounts for temperature, salinity)
  - a numerical constant value in cm^2/s, in which case the numerical value *needs to be defined as a string* eg "2e-5" in the now-fixed commented out example above